### PR TITLE
Allow writing audit exports to disk via preload APIs; HTML/JSONL/PDF …

### DIFF
--- a/apps/desktop/electron/preload.ts
+++ b/apps/desktop/electron/preload.ts
@@ -82,6 +82,19 @@ contextBridge.exposeInMainWorld('rainvibe', {
     }
   }
   ,
+  writeBytesBase64(relPath: string, base64: string): boolean {
+    try {
+      const abs = path.resolve(repoRoot(), relPath);
+      if (!abs.startsWith(repoRoot())) return false;
+      fs.mkdirSync(path.dirname(abs), { recursive: true });
+      const buf = Buffer.from(base64, 'base64');
+      fs.writeFileSync(abs, buf);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+  ,
   gitStatus(): { status: string; path: string }[] {
     try {
       const root = repoRoot();

--- a/apps/desktop/src/ui/App.tsx
+++ b/apps/desktop/src/ui/App.tsx
@@ -232,18 +232,17 @@ const App: React.FC = () => {
             audit={{
               events: events as any,
               onExport: (fmt) => {
+                const ts = new Date().toISOString().replace(/[:.]/g, '-');
                 if (fmt === 'html') {
                   const html = exportHTML(events as any);
-                  const url = URL.createObjectURL(new Blob([html], { type: 'text/html' }));
-                  window.open(url);
+                  (window as any).rainvibe?.writeTextFile?.(`.rainvibe/exports/audit-${ts}.html`, html);
                 } else if (fmt === 'jsonl') {
                   const txt = exportJSONL(events as any);
-                  const url = URL.createObjectURL(new Blob([txt], { type: 'application/json' }));
-                  window.open(url);
+                  (window as any).rainvibe?.writeTextFile?.(`.rainvibe/exports/audit-${ts}.jsonl`, txt);
                 } else {
                   const bin = exportPDF(events as any);
-                  const url = URL.createObjectURL(new Blob([bin], { type: 'application/pdf' }));
-                  window.open(url);
+                  const b64 = btoa(String.fromCharCode(...Array.from(bin)));
+                  (window as any).rainvibe?.writeBytesBase64?.(`.rainvibe/exports/audit-${ts}.pdf`, b64);
                 }
               }
             }}

--- a/apps/desktop/src/vite-env.d.ts
+++ b/apps/desktop/src/vite-env.d.ts
@@ -11,6 +11,7 @@ declare global {
       gitStatus?: () => { status: string; path: string }[];
       appendAudit?: (line: string) => boolean;
       revealInOS?: (relPath: string) => boolean;
+      writeBytesBase64?: (relPath: string, base64: string) => boolean;
     };
   }
 }


### PR DESCRIPTION
…saved to .rainvibe/exports with timestamps.