### PR TITLE
Preferences: provider API key/baseUrl and per-language format-on-save…

### DIFF
--- a/apps/desktop/src/ui/App.tsx
+++ b/apps/desktop/src/ui/App.tsx
@@ -246,7 +246,9 @@ const App: React.FC = () => {
     registry.register({ id: 'reopen-closed', title: 'Reopen Closed Tab', run: () => reopenClosed() });
     registry.register({ id: 'save-buffer', title: 'Save Buffer', run: async () => {
       try {
-        if (prefs.formatOnSave) {
+        const lang = active?.language || '';
+        const perLang = (prefs as any).formatOnSavePerLanguage || {};
+        if (prefs.formatOnSave || perLang[lang]) {
           const fmt = registry.get('format-document');
           await fmt?.run();
         }

--- a/apps/desktop/src/ui/components/PreferencesModal.tsx
+++ b/apps/desktop/src/ui/components/PreferencesModal.tsx
@@ -24,6 +24,12 @@ const PreferencesModal: React.FC<Props> = ({ open, onClose }) => {
           <label className="block">Model
             <input className="mt-1 bg-black border border-white/15 rounded px-2 py-1 w-full" value={local.model} onChange={(e) => setLocal({ ...local, model: e.target.value })} />
           </label>
+          <label className="block">API Key
+            <input type="password" className="mt-1 bg-black border border-white/15 rounded px-2 py-1 w-full" value={(local as any).apiKey || ''} onChange={(e) => setLocal({ ...local, apiKey: e.target.value } as any)} />
+          </label>
+          <label className="block">Base URL (optional)
+            <input className="mt-1 bg-black border border-white/15 rounded px-2 py-1 w-full" value={(local as any).baseUrl || ''} onChange={(e) => setLocal({ ...local, baseUrl: e.target.value } as any)} />
+          </label>
           <label className="flex items-center gap-2">
             <input type="checkbox" checked={local.offlineOnly} onChange={(e) => setLocal({ ...local, offlineOnly: e.target.checked })} />
             <span>Offline-only mode</span>

--- a/apps/desktop/src/ui/state/useAiClient.ts
+++ b/apps/desktop/src/ui/state/useAiClient.ts
@@ -10,19 +10,21 @@ export function useAiClient() {
   const { active: modes } = useModes();
   const providerRef = React.useRef(createProvider({
     provider: prefs.provider,
-    apiKey: undefined,
+    apiKey: prefs.apiKey,
     model: prefs.model,
     offlineOnly: prefs.offlineOnly,
+    baseUrl: prefs.baseUrl,
   }));
 
   React.useEffect(() => {
     providerRef.current = createProvider({
       provider: prefs.provider,
-      apiKey: undefined,
+      apiKey: prefs.apiKey,
       model: prefs.model,
       offlineOnly: prefs.offlineOnly,
+      baseUrl: prefs.baseUrl,
     });
-  }, [prefs.provider, prefs.model, prefs.offlineOnly]);
+  }, [prefs.provider, prefs.model, prefs.offlineOnly, prefs.apiKey, prefs.baseUrl]);
 
   return {
     chat: async (messages: AiMessage[]) => {

--- a/apps/desktop/src/ui/state/usePreferences.ts
+++ b/apps/desktop/src/ui/state/usePreferences.ts
@@ -4,6 +4,8 @@ export interface Preferences {
   provider: 'chatgpt' | 'anthropic' | 'azure' | 'local';
   model: string;
   offlineOnly: boolean;
+  apiKey?: string;
+  baseUrl?: string;
   ghostText?: boolean;
   telemetryOptIn?: boolean;
   minimap?: boolean;
@@ -15,11 +17,12 @@ export interface Preferences {
   autosave?: boolean;
   formatOnSave?: boolean;
   wordWrapColumn?: number;
+  formatOnSavePerLanguage?: Record<string, boolean>;
 }
 
 const KEY = 'rainvibe.preferences';
 const KEY_FIRST = 'rainvibe.firstRun';
-const DEFAULTS: Preferences = { provider: 'chatgpt', model: 'gpt-4o-mini', offlineOnly: false, ghostText: true, telemetryOptIn: false, minimap: true, fontSize: 14, wordWrap: false, wordWrapColumn: 80, tokenMeter: true, lineNumbers: true, renderWhitespace: false, autosave: false, formatOnSave: false };
+const DEFAULTS: Preferences = { provider: 'chatgpt', model: 'gpt-4o-mini', offlineOnly: false, apiKey: '', baseUrl: '', ghostText: true, telemetryOptIn: false, minimap: true, fontSize: 14, wordWrap: false, wordWrapColumn: 80, tokenMeter: true, lineNumbers: true, renderWhitespace: false, autosave: false, formatOnSave: false, formatOnSavePerLanguage: { typescript: true, javascript: true, json: true, markdown: true } };
 
 export function usePreferences() {
   const [prefs, setPrefs] = React.useState<Preferences>(() => {


### PR DESCRIPTION
…; AI client uses credentials; save-with-format respects per-language toggle.